### PR TITLE
Combine client and server classpaths into common classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,3 +95,6 @@ def configure(project) {
 		}
 	}
 }
+
+sourceSets.main.compileClasspath += project(':client').sourceSets.main.compileClasspath
+sourceSets.main.compileClasspath += project(':server').sourceSets.main.compileClasspath


### PR DESCRIPTION
This PR adds both the dependencies of the client classpath and the dependencies of the server classpath to that of the common classpath. Such as:

- both Minecraft JARs
- OSL modules
- non-mod libraries
- mapped mod dependencies

This makes IDE integration work better.
IDEA will no longer act as if the dependencies of the client and server projects are not present when writing common code. Which makes major IDE errors go away, and automatic imports work again.

## Before

![Before](https://cdn.discordapp.com/attachments/922266041663496202/1169406824710144130/image.png "Before")

## After

![After](https://cdn.discordapp.com/attachments/922266041663496202/1169663369737945098/image.png "After")